### PR TITLE
fix 404 being thrown for upload endpoint

### DIFF
--- a/internal/server/routes/base.go
+++ b/internal/server/routes/base.go
@@ -118,8 +118,4 @@ func BindRoutesBase(server *fiber.App, imageSource imagesources.ImageSource) {
 		MaxAge: 86400, // 24 hours
 	})
 
-	server.Use(func(c *fiber.Ctx) error {
-		return c.Status(http.StatusNotFound).Render("404", 0)
-	})
-
 }

--- a/main.go
+++ b/main.go
@@ -73,6 +73,11 @@ func main() {
 		routes.BindAPIUpload(server, &src)
 	}
 
+	// Register 404 handler last, after all other routes
+	server.Use(func(c *fiber.Ctx) error {
+		return c.Status(404).Render("404", 0)
+	})
+
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Server.Port))
 	if err != nil {
 		log.Panicw("failed to start listener on port", "port", cfg.Server.Port, "error", err)


### PR DESCRIPTION
Currently the upload route doesn't seem to be working at all - it is throwing 404s because a catch-all handler is added as part of the base routes, which takes priority over the additional api upload route. 

This fixes this issue by moving the catch all handler to the main.go file to be registered *after* the api upload route.