### PR TITLE
feat: allow subdirectory image paths in transform URLs without encoded slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ GET /cgi/images/tr:quality=100/image1.jpg
 # Resize to 300px width, auto height
 GET /cgi/images/tr:width=300/image1.jpg
 
+# Subdirectory path
+GET /cgi/images/tr:width=300,fit=contain/garden/flower.png
+
 # Resize with specific fit mode and background
 GET /cgi/images/tr:width=400,height=300,fit=pad,background=blue/image1.jpg
 
@@ -153,7 +156,7 @@ curl -X PUT http://localhost:8080/api/v0/images \
    - API: `http://localhost:8080/cgi/images/tr:<transformations>/<image-name>`
    - Demo page: `http://localhost:8080/demo`
 
-   > Always URL escape <image-name> path
+   > URL escape `<image-name>` when it contains reserved URL characters (for example `?` or `#`)
 
 ### Production Build
 

--- a/internal/server/routes/route_transform.go
+++ b/internal/server/routes/route_transform.go
@@ -16,12 +16,12 @@ import (
 )
 
 func BindRouteTransformation(server *fiber.App, k *kritiimages.KritiImages) {
-	server.Get(`/cgi/images/tr\::options?/:image`, func(c *fiber.Ctx) error {
+	server.Get(`/cgi/images/tr\::options?/*`, func(c *fiber.Ctx) error {
 		optionsStr := c.Params("options", "")
-		imagePath, err := url.PathUnescape(c.Params("image", ""))
+		imagePath, err := url.PathUnescape(c.Params("*", ""))
 		if err != nil {
 			log.Warn("failed to unescape image path, using original value", "path", imagePath)
-			imagePath = c.Params("image", "")
+			imagePath = c.Params("*", "")
 		}
 		log.Infow("new request", "options", optionsStr, "path", imagePath)
 

--- a/internal/server/routes/route_transform_test.go
+++ b/internal/server/routes/route_transform_test.go
@@ -1,0 +1,105 @@
+package routes
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kritihq/kriti-images/internal/imagesources"
+	"github.com/kritihq/kriti-images/pkg/kritiimages"
+)
+
+func TestBindRouteTransformation_SubdirectoryPath(t *testing.T) {
+	app := setupTransformTestApp(t)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "plain subdirectory path",
+			path: "/cgi/images/tr:quality=100/garden/flower.png",
+		},
+		{
+			name: "encoded slash path",
+			path: "/cgi/images/tr:quality=100/garden%2Fflower.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("app.Test() error = %v", err)
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("unexpected status code: got %d, body=%s", resp.StatusCode, string(body))
+			}
+
+			if got := resp.Header.Get("Content-Type"); got != "image/png" {
+				t.Fatalf("unexpected content type: got %q", got)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed to read response body: %v", err)
+			}
+			if len(body) == 0 {
+				t.Fatalf("expected non-empty image response body")
+			}
+		})
+	}
+}
+
+func setupTransformTestApp(t *testing.T) *fiber.App {
+	t.Helper()
+
+	basePath := t.TempDir()
+	filePath := filepath.Join(basePath, "garden", "flower.png")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("failed to create test directory: %v", err)
+	}
+
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	img.Set(1, 0, color.RGBA{G: 255, A: 255})
+	img.Set(0, 1, color.RGBA{B: 255, A: 255})
+	img.Set(1, 1, color.RGBA{R: 255, G: 255, A: 255})
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create test image: %v", err)
+	}
+	if err := png.Encode(f, img); err != nil {
+		_ = f.Close()
+		t.Fatalf("failed to encode test image: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close test image file: %v", err)
+	}
+
+	validations := &imagesources.SourceImageValidations{
+		MaxImageDimension:  8192,
+		MaxFileSizeInBytes: 50 * 1024 * 1024,
+	}
+	localSource := kritiimages.NewImageSourceLocal(basePath, validations)
+	httpSource := kritiimages.NewImageSourceURL(validations)
+	service := kritiimages.New(map[string]kritiimages.ImageSource{
+		"local": localSource,
+		"http":  httpSource,
+	}, localSource)
+
+	app := fiber.New()
+	BindRouteTransformation(app, service)
+	return app
+}


### PR DESCRIPTION
Updates the transform route to capture image paths as a greedy suffix instead of a single path segment. This is to allow subdirectory organization in URLs like /cgi/images/tr:.../garden/flower.png, which are easier to read than %2F encoded slashes. Compatibility with existing encoded-slash URLs (%2F) is preserved.

 - Switched transform route param from single-segment :image to greedy *
 - Updated image-path param to read from wildcard instead of named parameter
 - Added relevant test
 - Updated README to clarify

Tested with:
 - `go test ./...`

(AI used; human reviewed)